### PR TITLE
add some options

### DIFF
--- a/lib/declaimer/builder.ex
+++ b/lib/declaimer/builder.ex
@@ -1,11 +1,17 @@
 defmodule Declaimer.Builder do
+  alias Declaimer.TagAttribute
+
   def build(triples), do: build(triples, [], [])
 
+  def build([{:div, content, [{:theme, theme} | other_attrs]} | rest], themes, acc) do
+    attrs = TagAttribute.add_class(other_attrs, theme)
+    html = do_build({:div, content, attrs})
+    build(rest, [theme | themes], [html | acc])
+  end
   def build([triple | rest], themes, acc) do
     html = do_build(triple)
     build(rest, themes, [html | acc])
   end
-
   def build([], themes, acc) do
     html = acc |> Enum.reverse |> Enum.join("\n")
     {html, themes}
@@ -26,16 +32,6 @@ defmodule Declaimer.Builder do
     "<#{tag}>#{contents}</#{tag}>"
   end
   defp htmlize(tag, contents, attrs) do
-    "<#{tag} #{stringify_attributes(attrs)}>#{contents}</#{tag}>"
-  end
-
-  defp stringify_attributes(attrs) when is_list(attrs) do
-    Enum.map(attrs, &stringify_attributes/1) |> Enum.join(" ")
-  end
-  defp stringify_attributes({key, val}) when is_list(val) do
-    ~s(#{key}="#{Enum.join(val, " ")}")
-  end
-  defp stringify_attributes({key, val}) when is_binary(val) do
-    ~s(#{key}="#{val}")
+    "<#{tag} #{TagAttribute.to_string attrs}>#{contents}</#{tag}>"
   end
 end

--- a/lib/declaimer/tag_attribute.ex
+++ b/lib/declaimer/tag_attribute.ex
@@ -1,0 +1,30 @@
+defmodule Declaimer.TagAttribute do
+
+  import Kernel, except: [to_string: 1]
+
+  def add_class(attrs, nil) do
+    attrs
+  end
+  def add_class(attrs, class) do
+    class = "#{class}"
+    Keyword.update(attrs, :class, [class], &[class | &1])
+  end
+
+  def put_new_theme(attrs, nil) do
+    attrs
+  end
+  def put_new_theme(attrs, theme) do
+    Keyword.put_new(attrs, :theme, "#{theme}")
+  end
+
+  def to_string(attrs) when is_list(attrs) do
+    Enum.map(attrs, &to_string/1) |> Enum.join(" ")
+  end
+  def to_string({key, val}) when is_list(val) do
+    values = val |> Enum.filter(&(not nil?(&1))) |> Enum.join(" ")
+    ~s(#{key}="#{values}")
+  end
+  def to_string({key, val}) when is_binary(val) do
+    ~s(#{key}="#{val}")
+  end
+end

--- a/test/unit/dsl_test.exs
+++ b/test/unit/dsl_test.exs
@@ -87,7 +87,7 @@ defmodule DSLTest do
   end
 
   test "table without headers" do
-    table = table headers: false do
+    table = table header: false do
       ["one", "two"]
       [  100,   200]
       [  300,   400]
@@ -102,31 +102,39 @@ defmodule DSLTest do
 
   test "image" do
     image = image("img/photo.png")
-
     assert image == {:img, [], src: "img/photo.png"}
   end
 
-  test "slide" do
-    slide = slide "The Slide" do
-      text "Lorem ipsum"
-      code "elixir" do
-        "iex> 1+2"
-      end
-    end
+  test "image with size" do
+    image = image("img/photo.png", size: :full)
+    assert image == {:img, [], src: "img/photo.png", class: ["full"]}
+  end
 
-    expected = {:div, [
+  test "slide" do
+    {:div, contents, attrs} =
+      slide "The Slide", theme: "dark" do
+        text "Lorem ipsum"
+        code "elixir" do
+          "iex> 1+2"
+        end
+      end
+
+    expected_contents = [
         {:h2, ["The Slide"], []},
         {:p, ["Lorem ipsum"], []},
         {:pre, [
             {:code, ["iex> 1+2"], class: ["elixir"]}
         ], []}
-      ], class: ["slide"]}
+      ]
 
-    assert slide == expected
+    assert contents == expected_contents
+    assert attrs[:theme] == "dark"
+    assert "slide" in attrs[:class]
+    refute "dark"  in attrs[:class]
   end
 
   test "presentation" do
-    p = presentation do
+    p = presentation theme: "plain" do
       title "Title"
       subtitle "Subtitle"
       author "me"
@@ -139,7 +147,7 @@ defmodule DSLTest do
         end
       end
 
-      slide "List" do
+      slide "List", theme: :dark do
         list :bullet do
           item "one"
           item "two"
@@ -155,23 +163,25 @@ defmodule DSLTest do
     end
 
     expected = """
+    <div class="cover">
     <h1 class="title">Title</h1>.*
     <div class="subtitle">Subtitle</div>.*
     <div class="author">me</div>.*
-    <div class="slide">.*
+    </div>.*
+    <div class="(slide plain|plain slide)">.*
     <h2>Intro</h2>.*
     <blockquote>Lorem ipsum</blockquote>.*
     <pre><code class="elixir">iex> 1\\+2.*
     3</code></pre>.*
     </div>.*
-    <div class="slide">.*
+    <div class="(slide dark|dark slide)">.*
     <h2>List</h2>.*
     <ul>.*
     <li>one</li>.*
     <li>two</li>.*
     </ul>.*
     </div>.*
-    <div class="slide">.*
+    <div class="(slide plain|plain slide)">.*
     <h2>Table</h2>.*
     <table>.*
     <tr>.*

--- a/test/unit/tag_attribute_test.exs
+++ b/test/unit/tag_attribute_test.exs
@@ -1,0 +1,27 @@
+defmodule TagAttributeTest do
+  import Declaimer.TagAttribute
+
+  use ExUnit.Case
+
+  test "add_class" do
+    assert add_class([a: 1], nil) == [a: 1]
+
+    attrs = add_class([a: 1], :foo)
+    assert {:a, 1} in attrs
+    assert {:class, ["foo"]} in attrs
+
+    [class: classes] = add_class([class: ["foo"]], "bar")
+    assert "foo" in classes
+    assert "bar" in classes
+  end
+
+  test "put_new_theme" do
+    assert put_new_theme([a: 1], nil) == [a: 1]
+
+    attrs = put_new_theme([a: 1], :foo)
+    assert {:a, 1} in attrs
+    assert {:theme, "foo"} in attrs
+
+    assert put_new_theme([theme: "foo"], :bar) == [theme: "foo"]
+  end
+end


### PR DESCRIPTION
This PR adds the feature to support following options
- `presentation theme: "foo"`
- `slide theme: "foo"`
- `image size: "foo"`

They just add a class to HTML, doesn't generate any css.
