### PR TITLE
support highlight.js

### DIFF
--- a/lib/declaimer/asset.ex
+++ b/lib/declaimer/asset.ex
@@ -18,9 +18,10 @@ defmodule Declaimer.Asset do
       end
 
       slide "Page 2", theme: :dark do
-        code "elixir" do
-          "iex> 1+2"
-          "3"
+        code "markdown" do
+          "# Head"
+          "* one"
+          "* two"
         end
       end
     end

--- a/lib/declaimer/dsl.ex
+++ b/lib/declaimer/dsl.ex
@@ -71,11 +71,12 @@ defmodule Declaimer.DSL do
                  end
       end
 
-      build [{
+      {html, themes} = build([{
         :div,
         unquote(metadata),
         [class: ["cover", "slide"], theme: unquote(theme)]
-      } | slides]
+      } | slides])
+      {html, themes, unquote(opts)}
     end
 	end
 

--- a/lib/mix/tasks/declaimer/compile.ex
+++ b/lib/mix/tasks/declaimer/compile.ex
@@ -1,6 +1,7 @@
 defmodule Mix.Tasks.Declaimer.Compile do
   def run(_) do
-    {{html, themes}, _} = Code.eval_file("presentation.exs")
+    {{html, themes, opts}, _} = Code.eval_file("presentation.exs")
+    highlight = Keyword.get(opts, :highlight_js_theme, "default")
 
     # generate css !!
     # this does not remove existing css because the user may edit them
@@ -19,7 +20,15 @@ defmodule Mix.Tasks.Declaimer.Compile do
     if File.exists?(html_file) do
       File.rm!(html_file)
     end
-    File.write!(html_file, EEx.eval_string(template_eex, body: html, themes: themes))
+    File.write!(
+      html_file,
+      EEx.eval_string(
+        template_eex,
+        body: html,
+        themes: themes,
+        highlight_theme: highlight
+      )
+    )
   end
 
   defp template_eex do
@@ -33,12 +42,16 @@ defmodule Mix.Tasks.Declaimer.Compile do
         <%= Enum.map themes, fn (theme) -> %>
           <link type="text/css" media="screen" rel="stylesheet" href="css/<%= theme %>.css">
         <% end %>
+        <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/<%= highlight_theme %>.min.css">
       </head>
       <body>
         <%= body %>
 
         <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
         <script type="text/javascript" src="js/presentation.js"></script>
+
+        <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/highlight.min.js"></script>
+        <script type="text/javascript">hljs.initHighlightingOnLoad();</script>
       </body>
     </html>
     """

--- a/test/unit/dsl_test.exs
+++ b/test/unit/dsl_test.exs
@@ -134,7 +134,7 @@ defmodule DSLTest do
   end
 
   test "presentation" do
-    {html, _} = presentation do
+    {html, themes, opts} = presentation highlight_js_theme: "monokai" do
       title "Title"
       subtitle "Subtitle"
       author "me"
@@ -199,5 +199,7 @@ defmodule DSLTest do
     |> Regex.compile!("sm")
 
     assert html =~ expected
+    assert themes == ["dark"]
+    assert opts == [highlight_js_theme: "monokai"]
   end
 end


### PR DESCRIPTION
This makes the macro `presentation` accept an option `:highlight_js_theme`.
Code in presentation will be highlighted if the given theme is valid.

with this, the options which are passed to `presentation` will be return as an element of a tuple `{html, themes, opts}`. This change makes adding more options easy.
