### PR TITLE
Config file

### DIFF
--- a/lib/declaimer/asset.ex
+++ b/lib/declaimer/asset.ex
@@ -28,6 +28,15 @@ defmodule Declaimer.Asset do
     """
   end
 
+  def config_exs do
+    """
+    use Mix.Config
+
+    config :declaimer,
+      highlight_js_theme: "hybrid"
+    """
+  end
+
   def presentation_js do
     """
     $(function () {

--- a/lib/declaimer/asset.ex
+++ b/lib/declaimer/asset.ex
@@ -33,6 +33,8 @@ defmodule Declaimer.Asset do
     use Mix.Config
 
     config :declaimer,
+      source_exs: "presentation.exs",
+      output_html: "presentation.html",
       highlight_js_theme: "hybrid"
     """
   end

--- a/lib/mix/tasks/declaimer/compile.ex
+++ b/lib/mix/tasks/declaimer/compile.ex
@@ -1,7 +1,6 @@
 defmodule Mix.Tasks.Declaimer.Compile do
   def run(_) do
     {{html, themes, opts}, _} = Code.eval_file("presentation.exs")
-    highlight = Keyword.get(opts, :highlight_js_theme, "default")
 
     # generate css !!
     # this does not remove existing css because the user may edit them
@@ -17,16 +16,15 @@ defmodule Mix.Tasks.Declaimer.Compile do
 
     # generate html !!
     html_file = "presentation.html"
-    if File.exists?(html_file) do
-      File.rm!(html_file)
-    end
+    if File.exists?(html_file), do: File.rm!(html_file)
+
     File.write!(
       html_file,
       EEx.eval_string(
         template_eex,
         body: html,
         themes: themes,
-        highlight_theme: highlight
+        highlight_theme: highlight_js_theme(opts)
       )
     )
   end
@@ -55,5 +53,10 @@ defmodule Mix.Tasks.Declaimer.Compile do
       </body>
     </html>
     """
+  end
+
+  defp highlight_js_theme(opts) do
+    theme = Application.get_env(:declaimer, :highlight_js_theme, "hybrid")
+    Keyword.get(opts, :highlight_js_theme, theme)
   end
 end

--- a/lib/mix/tasks/declaimer/compile.ex
+++ b/lib/mix/tasks/declaimer/compile.ex
@@ -1,6 +1,6 @@
 defmodule Mix.Tasks.Declaimer.Compile do
   def run(_) do
-    {{html, themes, opts}, _} = Code.eval_file("presentation.exs")
+    {{html, themes, opts}, _} = Code.eval_file(source_exs)
 
     # generate css !!
     # this does not remove existing css because the user may edit them
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Declaimer.Compile do
     end
 
     # generate html !!
-    html_file = "presentation.html"
+    html_file = output_html
     if File.exists?(html_file), do: File.rm!(html_file)
 
     File.write!(
@@ -53,6 +53,14 @@ defmodule Mix.Tasks.Declaimer.Compile do
       </body>
     </html>
     """
+  end
+
+  defp source_exs do
+    Application.get_env(:declaimer, :source_exs, "presentation.exs")
+  end
+
+  defp output_html do
+    Application.get_env(:declaimer, :output_html, "presentation.html")
   end
 
   defp highlight_js_theme(opts) do

--- a/lib/mix/tasks/declaimer/init.ex
+++ b/lib/mix/tasks/declaimer/init.ex
@@ -19,6 +19,11 @@ defmodule Mix.Tasks.Declaimer.Init do
       create_sample_presentation path
     end
 
+    path = "config/config.exs"
+    if nonsense_config_file?(path) do
+      create_config_exs path
+    end
+
     path = "js/presentation.js"
     unless File.exists?(path) do
       create_presentation_js path
@@ -35,8 +40,17 @@ defmodule Mix.Tasks.Declaimer.Init do
     end
   end
 
+  # TODO functions generation
+  # [:sample_presentation, :config_file, ... ]
+  # |> Enum.each fn (name) -> ...
+  #
+  # also check existence
   defp create_sample_presentation(filepath) do
     File.write!(filepath, Asset.sample_presentation_exs)
+  end
+
+  defp create_config_exs(filepath) do
+    File.write!(filepath, Asset.config_exs)
   end
 
   defp create_presentation_js(filepath) do
@@ -49,5 +63,15 @@ defmodule Mix.Tasks.Declaimer.Init do
 
   defp create_reset_css(filepath) do
     File.write!(filepath, Asset.reset_css)
+  end
+
+  defp nonsense_config_file?(filepath) do
+    filepath
+    |> File.stream!
+    |> Stream.map(&String.strip/1)
+    |> Stream.filter(&(String.first(&1) != "#"))
+    |> Stream.filter(&(not Regex.match? ~r/\A\z/, &1))
+    |> Enum.count
+    |> Kernel.<=(1)
   end
 end

--- a/test/task/init_test.exs
+++ b/test/task/init_test.exs
@@ -11,7 +11,8 @@ defmodule InitTest do
 
   test "directory structure" do
     ["mix.exs", "presentation.exs", "config", "img",
-     "js/presentation.js", "css/base.css", "css/reset.css"]
+     "js/presentation.js", "css/base.css", "css/reset.css",
+     "config/config.exs"]
     |> Enum.each(& assert(File.exists? &1))
 
     ["lib", "test"]
@@ -23,6 +24,12 @@ defmodule InitTest do
 
     assert content =~ ~r/use Declaimer/
     assert content =~ ~r/presentation do/
+  end
+
+  test "content of config.exs" do
+    content = File.read!("config/config.exs")
+
+    assert content == Asset.config_exs
   end
 
   test "content of presentation.js" do

--- a/test/unit/asset_test.exs
+++ b/test/unit/asset_test.exs
@@ -14,7 +14,7 @@ defmodule AssetTest do
   end
 
   test "content of base.css" do
-    assert Asset.base_css =~ "div.slide.active {"
+    assert Asset.base_css =~ ".slide.active {"
   end
 
   test "content of normalize.css" do


### PR DESCRIPTION
This make declaimer utilize `config/config.exs`.
Mainly in `compile` task, it references configuration.

Followings are the todays items in `cofig.exs`
- `source_exs`: defaults to "presentation.exs"
- `output_html`: defaults to "presentation.html"
- `highlight_js_theme`: defaults to "hybrid"
