### PR TITLE
add left and right

### DIFF
--- a/lib/declaimer/asset.ex
+++ b/lib/declaimer/asset.ex
@@ -176,22 +176,14 @@ defmodule Declaimer.Asset do
       font-size: 10rem;
     }
 
-    .slide > ul {
-      margin-left: 7%;
+    .slide ul {
+      margin-left: 5rem;
       font-size: 4rem;
     }
 
-    .slide > ol {
-      margin-left: 10%;
+    .slide ol {
+      margin-left: 7rem;
       font-size: 4rem;
-    }
-
-    .slide ul ul, .slide ol ul {
-      margin-left: 4%;
-    }
-
-    .slide ul ol, .slide ol ol {
-      margin-left: 7%;
     }
 
     .slide li {
@@ -241,6 +233,16 @@ defmodule Declaimer.Asset do
     .slide img.width-max {
       height: auto;
       min-width: 100%;
+    }
+
+    .left-half {
+      width: 50%;
+      float: left;
+    }
+
+    .right-half {
+      width: 50%;
+      float: right;
     }
     """
   end

--- a/lib/declaimer/dsl.ex
+++ b/lib/declaimer/dsl.ex
@@ -9,7 +9,7 @@ defmodule Declaimer.DSL do
   def author(author),     do: {:div, [author],   class: ["author"]}
 
   # macro generation !!
-  @tags_with_no_arg [:cite, :item, :text, :table]
+  @tags_with_no_arg [:cite, :item, :text, :table, :left, :right]
   Enum.each @tags_with_no_arg, fn (tag) ->
     do_function_name = String.to_atom("do_" <> Atom.to_string(tag))
 
@@ -132,5 +132,13 @@ defmodule Declaimer.DSL do
     Enum.map rows, fn (row) ->
       {:tr, Enum.map(row, &{:td, [&1], []}), []}
     end
+  end
+
+  def do_left(_, contents) do
+    {:div, contents, class: ["left-half"]}
+  end
+
+  def do_right(_, contents) do
+    {:div, contents, class: ["right-half"]}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Declaimer.Mixfile do
 
   def project do
     [app: :declaimer,
-     version: "0.1.0",
+     version: "0.1.1",
      elixir: ">= 1.0.0",
      deps: deps]
   end

--- a/test/unit/dsl_test.exs
+++ b/test/unit/dsl_test.exs
@@ -110,6 +110,16 @@ defmodule DSLTest do
     assert image == {:img, [], src: "img/photo.png", class: ["full"]}
   end
 
+  test "left" do
+    left = left do: "left side"
+    assert left == {:div, ["left side"], class: ["left-half"]}
+  end
+
+  test "right" do
+    right = right do: "right side"
+    assert right == {:div, ["right side"], class: ["right-half"]}
+  end
+
   test "slide" do
     {:div, contents, attrs} =
       slide "The Slide", theme: "dark" do


### PR DESCRIPTION
This PR adds new DSL, `left` and `right`.

They enclose their contents in `<div class="(left|right)-half"></div>`.
It divides the slide into 2 parts.

One of the great use-case is placing an image on a side and its description on another side.
