### PR TITLE
add Declaimer.Config module and config of highlight.js path

### DIFF
--- a/lib/declaimer/config.ex
+++ b/lib/declaimer/config.ex
@@ -1,0 +1,14 @@
+defmodule Declaimer.Config do
+
+  [
+    {:source_exs,         "presentation.exs"},
+    {:output_html,        "presentation.html"},
+    {:highlight_js_theme, "hybrid"},
+    {:highlight_js_path,  "http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/highlight.min.js"}
+  ]
+  |> Enum.each fn ({key, default_value}) ->
+    def unquote(key)() do
+      Application.get_env(:declaimer, unquote(key), unquote(default_value))
+    end
+  end
+end

--- a/lib/mix/tasks/declaimer/compile.ex
+++ b/lib/mix/tasks/declaimer/compile.ex
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Declaimer.Compile do
+  alias Declaimer.Config
+
   def run(_) do
-    {{html, themes, opts}, _} = Code.eval_file(source_exs)
+    {{html, themes, opts}, _} = Code.eval_file(Config.source_exs)
 
     # generate css !!
     # this does not remove existing css because the user may edit them
@@ -15,7 +17,7 @@ defmodule Mix.Tasks.Declaimer.Compile do
     end
 
     # generate html !!
-    html_file = output_html
+    html_file = Config.output_html
     if File.exists?(html_file), do: File.rm!(html_file)
 
     File.write!(
@@ -24,7 +26,8 @@ defmodule Mix.Tasks.Declaimer.Compile do
         template_eex,
         body: html,
         themes: themes,
-        highlight_theme: highlight_js_theme(opts)
+        highlight_js_theme: highlight_js_theme(opts),
+        highlight_js_path: Config.highlight_js_path
       )
     )
   end
@@ -40,7 +43,7 @@ defmodule Mix.Tasks.Declaimer.Compile do
         <%= Enum.map themes, fn (theme) -> %>
           <link type="text/css" rel="stylesheet" href="css/<%= theme %>.css">
         <% end %>
-        <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/<%= highlight_theme %>.min.css">
+        <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/styles/<%= highlight_js_theme %>.min.css">
       </head>
       <body>
         <%= body %>
@@ -48,23 +51,14 @@ defmodule Mix.Tasks.Declaimer.Compile do
         <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
         <script type="text/javascript" src="js/presentation.js"></script>
 
-        <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/highlight.min.js"></script>
+        <script type="text/javascript" src="<%= highlight_js_path %>"></script>
         <script type="text/javascript">hljs.initHighlightingOnLoad();</script>
       </body>
     </html>
     """
   end
 
-  defp source_exs do
-    Application.get_env(:declaimer, :source_exs, "presentation.exs")
-  end
-
-  defp output_html do
-    Application.get_env(:declaimer, :output_html, "presentation.html")
-  end
-
   defp highlight_js_theme(opts) do
-    theme = Application.get_env(:declaimer, :highlight_js_theme, "hybrid")
-    Keyword.get(opts, :highlight_js_theme, theme)
+    Keyword.get(opts, :highlight_js_theme, Config.highlight_js_theme)
   end
 end

--- a/test/unit/config_test.exs
+++ b/test/unit/config_test.exs
@@ -1,0 +1,38 @@
+defmodule ConfigTest do
+  alias Declaimer.Config
+  use ExUnit.Case
+
+  test "source_exs" do
+    Application.delete_env(:declaimer, :source_exs)
+    assert Config.source_exs == "presentation.exs"
+
+    Application.put_env(:declaimer, :source_exs, "source.exs")
+    assert Config.source_exs == "source.exs"
+  end
+
+  test "output_html" do
+    Application.delete_env(:declaimer, :output_html)
+    assert Config.output_html == "presentation.html"
+
+    Application.put_env(:declaimer, :output_html, "output.html")
+    assert Config.output_html == "output.html"
+  end
+
+  test "highlight_js_theme" do
+    Application.delete_env(:declaimer, :highlight_js_theme)
+    assert Config.highlight_js_theme == "hybrid"
+
+    Application.put_env(:declaimer, :highlight_js_theme, "github")
+    assert Config.highlight_js_theme == "github"
+  end
+
+  test "highlight_js_path" do
+    Application.delete_env(:declaimer, :highlight_js_path)
+    assert Config.highlight_js_path ==
+      "http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.2/highlight.min.js"
+
+    Application.put_env(:declaimer, :highlight_js_path, "js/hljs.min.js")
+    assert Config.highlight_js_path == "js/hljs.min.js"
+  end
+end
+


### PR DESCRIPTION
This adds followings
- an module `Declaimer.Config`
  - wraps `Application.get_env`
  - make managing default values easy
- config `highlight_js_path`
  - highlight.js hosted on CDN colors only 22 languages.
  - downloading custom highlight.js and specifying where it is make the code bright
