### PR TITLE
add options for decoration

### DIFF
--- a/lib/declaimer/asset.ex
+++ b/lib/declaimer/asset.ex
@@ -164,6 +164,22 @@ defmodule Declaimer.Asset do
       font-size: 4rem;
     }
 
+    .slide .bold {
+      font-weight: bold;
+    }
+
+    .slide .italic {
+      font-style: italic;
+    }
+
+    .slide .strike {
+      text-decoration: line-through;
+    }
+
+    .slide .underline {
+      text-decoration: underline
+    }
+
     .slide .takahashi {
       height: 100%;
       width:  100%;

--- a/lib/declaimer/dsl.ex
+++ b/lib/declaimer/dsl.ex
@@ -55,12 +55,13 @@ defmodule Declaimer.DSL do
 
   # exceptional !!
   defmacro image(src, opts \\ []) do
-    attrs = TagAttribute.add_class([src: src], opts[:size])
+    attrs = TagAttribute.apply([src: src], opts)
     quote do: {:img, [], unquote(attrs)}
   end
 
-  defmacro takahashi(text, _opts \\ []) do
-    quote do: {:div, [{:p, [unquote text], []}], [class: ["takahashi"]]}
+  defmacro takahashi(text, opts \\ []) do
+    attrs = TagAttribute.add_class([], opts[:deco])
+    quote do: {:div, [{:p, [unquote text], unquote(attrs)}], [class: ["takahashi"]]}
   end
 
   defmacro presentation(opts \\ [], do: {:__block__, _, contents}) do
@@ -86,33 +87,33 @@ defmodule Declaimer.DSL do
 
   # worker functions !!
   def do_slide(title, opts, contents) do
-    attrs = TagAttribute.put_new_theme([class: ["slide"]], opts[:theme])
-
+    attrs = TagAttribute.apply([class: ["slide"]], opts)
     {:div, [{:h2, [title], []} | contents], attrs}
   end
 
-  def do_cite(_, contents) do
-    {:blockquote, contents, []}
+  def do_cite(opts, contents) do
+    {:blockquote, contents, TagAttribute.apply([], opts)}
   end
 
-  def do_item(_, contents) do
-    {:li, contents, []}
+  def do_item(opts, contents) do
+    {:li, contents, TagAttribute.apply([], opts)}
   end
 
-  def do_text(_, contents) do
-    {:p, contents, []}
+  def do_text(opts, contents) do
+    {:p, contents, TagAttribute.apply([], opts)}
   end
 
-  def do_code(lang, _, contents) do
-    {:pre, [{:code, contents, class: [lang]}], []}
+  def do_code(lang, opts, contents) do
+    attrs = TagAttribute.apply([], opts)
+    {:pre, [{:code, contents, class: [lang]}], attrs}
   end
 
-  def do_list(:bullet, _, contents) do
-    {:ul, contents, []}
+  def do_list(:bullet, opts, contents) do
+    {:ul, contents, TagAttribute.apply([], opts)}
   end
 
-  def do_list(:numbered, _, contents) do
-    {:ol, contents, []}
+  def do_list(:numbered, opts, contents) do
+    {:ol, contents, TagAttribute.apply([], opts)}
   end
 
   def do_list(invalid_type, _, _) do
@@ -120,8 +121,8 @@ defmodule Declaimer.DSL do
     raise ArgumentError, msg
   end
 
-  def do_link(url, _, contents) do
-    {:a, contents, [href: url]}
+  def do_link(url, opts, contents) do
+    {:a, contents, TagAttribute.apply([href: url], opts)}
   end
 
 	def do_table(opts, [first | rest] = rows) do

--- a/lib/declaimer/tag_attribute.ex
+++ b/lib/declaimer/tag_attribute.ex
@@ -2,8 +2,19 @@ defmodule Declaimer.TagAttribute do
 
   import Kernel, except: [to_string: 1]
 
+  def apply(attrs, opts) do
+    attrs
+    |> add_class(opts[:deco])
+    |> put_new_theme(opts[:theme])
+    |> add_class(opts[:size])
+  end
+
   def add_class(attrs, nil) do
     attrs
+  end
+  def add_class(attrs, [head | rest]) do
+    attrs = add_class(attrs, head)
+    add_class(attrs, rest)
   end
   def add_class(attrs, class) do
     class = "#{class}"

--- a/test/unit/tag_attribute_test.exs
+++ b/test/unit/tag_attribute_test.exs
@@ -1,7 +1,18 @@
 defmodule TagAttributeTest do
+  import Kernel, except: [apply: 2]
   import Declaimer.TagAttribute
 
   use ExUnit.Case
+
+  test "apply" do
+    opts = [theme: "bar", deco: ["bold", :strike]]
+    attrs = apply([class: ["foo"]], opts)
+
+    assert attrs[:theme] == "bar"
+    assert "foo"    in attrs[:class]
+    assert "bold"   in attrs[:class]
+    assert "strike" in attrs[:class]
+  end
 
   test "add_class" do
     assert add_class([a: 1], nil) == [a: 1]
@@ -13,6 +24,11 @@ defmodule TagAttributeTest do
     [class: classes] = add_class([class: ["foo"]], "bar")
     assert "foo" in classes
     assert "bar" in classes
+
+    [class: classes] = add_class([class: ["foo"]], ["bar", "baz"])
+    assert "foo" in classes
+    assert "bar" in classes
+    assert "baz" in classes
   end
 
   test "put_new_theme" do


### PR DESCRIPTION
This makes Declaimer DSL accepts `:deco` option.
valid values are followings.
- `bold`
- `italic`
- `strike`
- `underline`

combinations like `deco: ["bold", "underline"]` are allowed.
