### PR TITLE
Reform list macro

### DIFF
--- a/lib/declaimer/asset.ex
+++ b/lib/declaimer/asset.ex
@@ -11,7 +11,7 @@ defmodule Declaimer.Asset do
 
       slide "Page 1" do
         text "Hello World"
-        list :bullet do
+        bullet do
           item "こんにちわ"
           item "世界"
         end

--- a/lib/declaimer/dsl.ex
+++ b/lib/declaimer/dsl.ex
@@ -11,7 +11,7 @@ defmodule Declaimer.DSL do
   # macro generation !!
 
   # tags which take optional options and a do-end block
-  [:cite, :table, :left, :right]
+  [:cite, :table, :left, :right, :bullet, :numbered]
   |> Enum.each fn (tag) ->
     do_function_name = String.to_atom("do_" <> Atom.to_string(tag))
 
@@ -40,7 +40,7 @@ defmodule Declaimer.DSL do
   end
 
   # tags which accept one argument, optional option and one block
-  [:slide, :code, :list, :link]
+  [:slide, :code, :link]
   |> Enum.each fn (tag) ->
     do_function_name = String.to_atom("do_" <> Atom.to_string(tag))
 
@@ -117,19 +117,6 @@ defmodule Declaimer.DSL do
     {:pre, [{:code, contents, class: [lang]}], attrs}
   end
 
-  def do_list(:bullet, opts, contents) do
-    {:ul, contents, TagAttribute.apply([], opts)}
-  end
-
-  def do_list(:numbered, opts, contents) do
-    {:ol, contents, TagAttribute.apply([], opts)}
-  end
-
-  def do_list(invalid_type, _, _) do
-    msg = "'#{invalid_type}' is invalid list type. Use :bullet or :numbered."
-    raise ArgumentError, msg
-  end
-
   def do_link(url, opts, contents) do
     {:a, contents, TagAttribute.apply([href: url], opts)}
   end
@@ -158,5 +145,13 @@ defmodule Declaimer.DSL do
 
   def do_right(_, contents) do
     {:div, contents, class: ["right-half"]}
+  end
+
+  def do_bullet(_, contents) do
+    {:ul, contents, []}
+  end
+
+  def do_numbered(_, contents) do
+    {:ol, contents, []}
   end
 end

--- a/lib/declaimer/dsl.ex
+++ b/lib/declaimer/dsl.ex
@@ -29,7 +29,7 @@ defmodule Declaimer.DSL do
   end
 
   # tags which accept one argument and optional options
-  [:item, :text, :image, :takahashi]
+  [:o, :item, :text, :image, :takahashi]
   |> Enum.each fn (tag) ->
     do_function_name = String.to_atom("do_" <> Atom.to_string(tag))
 
@@ -95,8 +95,11 @@ defmodule Declaimer.DSL do
     {:blockquote, contents, TagAttribute.apply([], opts)}
   end
 
-  def do_item(text, opts) do
-    {:li, [text], TagAttribute.apply([], opts)}
+  [:do_o, :do_item]
+  |> Enum.each fn (name) ->
+    def unquote(name)(text, opts) do
+      {:li, [text], TagAttribute.apply([], opts)}
+    end
   end
 
   def do_text(text, opts) do

--- a/test/unit/dsl_test.exs
+++ b/test/unit/dsl_test.exs
@@ -37,17 +37,21 @@ defmodule DSLTest do
     assert code == {:pre, [{:code, ["iex> 1+2", "3"], class: ["elixir"]}], []}
   end
 
-  test "list" do
-    bullet = list :bullet do
-      item "one"
-      item "two"
-    end
-    numbered = list :numbered do
+  test "bullet" do
+    bullet = bullet do
       item "one"
       item "two"
     end
 
     assert bullet   == {:ul, [{:li, ["one"], []}, {:li, ["two"], []}], []}
+  end
+
+  test "numbered" do
+    numbered = numbered do
+      item "one"
+      item "two"
+    end
+
     assert numbered == {:ol, [{:li, ["one"], []}, {:li, ["two"], []}], []}
   end
 
@@ -171,7 +175,7 @@ defmodule DSLTest do
       end
 
       slide "List", theme: :dark do
-        list :bullet do
+        bullet do
           item "one"
           item "two"
         end

--- a/test/unit/dsl_test.exs
+++ b/test/unit/dsl_test.exs
@@ -39,17 +39,17 @@ defmodule DSLTest do
 
   test "bullet" do
     bullet = bullet do
-      item "one"
-      item "two"
+      o "one"
+      o "two"
     end
 
-    assert bullet   == {:ul, [{:li, ["one"], []}, {:li, ["two"], []}], []}
+    assert bullet == {:ul, [{:li, ["one"], []}, {:li, ["two"], []}], []}
   end
 
   test "numbered" do
     numbered = numbered do
-      item "one"
-      item "two"
+      o "one"
+      o "two"
     end
 
     assert numbered == {:ol, [{:li, ["one"], []}, {:li, ["two"], []}], []}
@@ -59,6 +59,7 @@ defmodule DSLTest do
     item = item "one"
 
     assert item == {:li, ["one"], []}
+    assert item == o("one")
   end
 
   test "link" do
@@ -176,8 +177,8 @@ defmodule DSLTest do
 
       slide "List", theme: :dark do
         bullet do
-          item "one"
-          item "two"
+          o "one"
+          o "two"
         end
       end
 


### PR DESCRIPTION
This will make following changes.
1. `list :bullet do end` and `list :numbered do end` are now `bullet do end` and `numbered do end` respectively.
2. `item` macro has an alias `o`
